### PR TITLE
Fix lockup in wifi shell when not using RTT (ST-2305)

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -49,13 +49,13 @@ static uint32_t scan_result;
 
 static struct net_mgmt_event_callback wifi_shell_mgmt_cb;
 
-#define print(sh, level, fmt, ...)					\
-	do {								\
-		if (sh) {						\
-			shell_fprintf(sh, level, fmt, ##__VA_ARGS__); \
-		} else {						\
-			printk(fmt, ##__VA_ARGS__);			\
-		}							\
+#define print(sh, level, fmt, ...)                                                                 \
+	do {                                                                                       \
+		if (sh) {                                                                          \
+			printk(fmt, ##__VA_ARGS__);                                                \
+		} else {                                                                           \
+			printk(fmt, ##__VA_ARGS__);                                                \
+		}                                                                                  \
 	} while (false)
 
 static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
@@ -216,7 +216,7 @@ static int cmd_wifi_connect(const struct shell *sh, size_t argc,
 			    char *argv[])
 {
 	struct net_if *iface = net_if_get_default();
-	static struct wifi_connect_req_params cnx_params;
+	struct wifi_connect_req_params cnx_params;
 
 	if (__wifi_args_to_params(argc - 1, &argv[1], &cnx_params)) {
 		shell_help(sh);


### PR DESCRIPTION
# Changes
WiFi shell prints using `shell_fprintf` if any wifi shell commands were run after boot. Otherwise, it uses printk.  `shell_fprintf` causes RTT flush and if RTT is not connected, it waits forever. So in the event that a user runs in wifi shell commands and then takes the unit off dock and triggers a wifi scan (eg: ground fix), the device would lock up and be rebooted with the watchdog.

This is an edge case and would only happen in that very first instance. After reboot, the `sh` variable is reset to null and the wifi shell uses `printk`. This would also never happen on release builds as there is no way to expect a shell command.

In any case, the easy fix here is to always use `printk`. I made it look awkward (duplicate statements in `if`/`else`) on purpose so we know why it was changed. Technically, I could have removed the if statement.

Another small change was remove `static` from a local variable because I found this in the upstream repo: https://github.com/nrfconnect/sdk-zephyr/commit/97ee180c72296d9b2d0f1f9b35a6c7180f61e851

# Testing
* Verified that lock-up happens prior to making the changes (using wifi shell, run `wifi scan`, take the unit off dock, trigger sos, unit locks up).
* Verified that after the change, the lock-up did not happen using same steps.