### PR TITLE
added `socket_offload_dns_deregister` (ST-1522)

### DIFF
--- a/include/zephyr/net/socket_offload.h
+++ b/include/zephyr/net/socket_offload.h
@@ -39,6 +39,11 @@ struct socket_dns_offload {
  */
 void socket_offload_dns_register(const struct socket_dns_offload *ops);
 
+/**
+ * @brief Deregister an offloaded socket DNS API interface.
+*/
+void socket_offload_dns_deregister( void );
+
 int socket_offload_getaddrinfo(const char *node, const char *service,
 			       const struct zsock_addrinfo *hints,
 			       struct zsock_addrinfo **res);

--- a/subsys/net/lib/sockets/socket_offload.c
+++ b/subsys/net/lib/sockets/socket_offload.c
@@ -14,6 +14,11 @@ LOG_MODULE_REGISTER(net_socket_offload, CONFIG_NET_SOCKETS_LOG_LEVEL);
 
 const struct socket_dns_offload *dns_offload;
 
+void socket_offload_dns_deregister()
+{
+	dns_offload = NULL;
+}
+
 void socket_offload_dns_register(const struct socket_dns_offload *ops)
 {
 	__ASSERT_NO_MSG(ops);


### PR DESCRIPTION
# Changes
- added simple API, `socket_offload_dns_deregister`, to allow deregistering offloaded API and consequently adding another one.
# Testing
- verified within application code that re-registration works and functions for appropriate device are called  