### PR TITLE
subsys/net/net_mgmt.c: Fix memory corruption in wait_on_iface

### DIFF
--- a/subsys/net/ip/net_mgmt.c
+++ b/subsys/net/ip/net_mgmt.c
@@ -236,29 +236,32 @@ static int mgmt_event_wait_call(struct net_if *iface,
 	net_mgmt_add_event_callback(&sync);
 
 	ret = k_sem_take(sync.sync_call, timeout);
-	if (ret == -EAGAIN) {
-		ret = -ETIMEDOUT;
-	} else {
-		if (!ret) {
-			if (raised_event) {
-				*raised_event = sync.raised_event;
-			}
+	if (ret < 0) {
+		if (ret == -EAGAIN) {
+			ret = -ETIMEDOUT;
+		}
 
-			if (event_iface) {
-				*event_iface = sync_data.iface;
-			}
+		net_mgmt_del_event_callback(&sync);
+		return ret;
+	}
+
+	if (raised_event) {
+		*raised_event = sync.raised_event;
+	}
+
+	if (event_iface) {
+		*event_iface = sync_data.iface;
+	}
 
 #ifdef CONFIG_NET_MGMT_EVENT_INFO
-			if (info) {
-				*info = sync.info;
+	if (info) {
+		*info = sync.info;
 
-				if (info_length) {
-					*info_length = sync.info_length;
-				}
-			}
-#endif /* CONFIG_NET_MGMT_EVENT_INFO */
+		if (info_length) {
+			*info_length = sync.info_length;
 		}
 	}
+#endif /* CONFIG_NET_MGMT_EVENT_INFO */
 
 	return ret;
 }


### PR DESCRIPTION
Applying patch from this pull request: https://github.com/zephyrproject-rtos/zephyr/pull/62302 
