### PR TITLE
net: don't overwrite net_if name after iface is initialized

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -4884,8 +4884,6 @@ void net_if_init(void)
 	net_tc_tx_init();
 
 	STRUCT_SECTION_FOREACH(net_if, iface) {
-		init_iface(iface);
-		if_count++;
 
 #if defined(CONFIG_NET_INTERFACE_NAME)
 		memset(net_if_get_config(iface)->name, 0,
@@ -4893,6 +4891,9 @@ void net_if_init(void)
 
 		set_default_name(iface);
 #endif
+
+		init_iface(iface);
+		if_count++;
 	}
 
 	if (if_count == 0) {


### PR DESCRIPTION
When interface names are enabled, a default name is applied after initialization. This overwrites any name that is set during the net_if init.

This change sets a default name first, and then allows net_if init to overwrite that default name if it chooses to.